### PR TITLE
105 - Change FFUpdate-DynamoLeagueScrape to handle player status for cut and unsigned player tables

### DIFF
--- a/FFUpdates-DynamoLeagueScrape/Players/PlayersRepository.cs
+++ b/FFUpdates-DynamoLeagueScrape/Players/PlayersRepository.cs
@@ -21,7 +21,7 @@ namespace DynamoLeagueScrape.Players
         void IPlayersRepository.UpdateSingle(clsPlayers player)
         {
             string query = @$"UPDATE Players
-                           SET TeamID = {player.TeamID}, PlayerImage = '{player.ImageURL}', contractThrough = {player.ContractThrough}, capSpace = {player.ContractValue}                      
+                           SET TeamID = {player.TeamID}, PlayerImage = '{player.ImageURL}', contractThrough = {player.ContractThrough}, capSpace = {player.ContractValue}, playerStatus = {player.PlayerStatus}                      
                            WHERE PlayerName = '{player.FullName}'";
 
             this.db.ExecuteScalar(query);

--- a/FFUpdates-DynamoLeagueScrape/Players/clsPlayers.cs
+++ b/FFUpdates-DynamoLeagueScrape/Players/clsPlayers.cs
@@ -24,12 +24,14 @@ namespace DynamoLeagueScrape.Players
 
         public int ContractValue { get; set; }
 
+        public int PlayerStatus { get; set; }
+
         public clsPlayers()
         {
 
         }
 
-        public clsPlayers(string name, int teamID, string position, string img, int contractThrough, int contractValue)
+        public clsPlayers(string name, int teamID, string position, string img, int contractThrough, int contractValue, int playerStatus)
         {
             FullName = name;
             TeamID = teamID;
@@ -37,6 +39,7 @@ namespace DynamoLeagueScrape.Players
             ImageURL = img;
             ContractThrough = contractThrough;
             ContractValue = contractValue;
+            PlayerStatus = playerStatus;
         }
 
         public static IPlayersRepository CreatePlayersRepository(string connString)

--- a/FFUpdates-DynamoLeagueScrape/Program.cs
+++ b/FFUpdates-DynamoLeagueScrape/Program.cs
@@ -20,31 +20,33 @@ namespace DynamoLeagueScrape
                 int tableIndex = 0;
                 foreach (HtmlNode table in doc.DocumentNode.SelectNodes("//tbody"))
                 {
-                    foreach (HtmlNode row in table.SelectNodes("tr"))
+                    if (table.SelectNodes("tr") != null)
                     {
-                        //Add scraped player to list
-                        lstPlayers.Add(
-                            new DynamoLeagueScrape.Players.clsPlayers(
-                                row.SelectNodes("td")[0].InnerText.Trim(),
-                                team.ID,
-                                row.SelectNodes("td")[1].InnerText.Trim(),
-                                row.SelectNodes("td")[0].SelectSingleNode("img").Attributes[0].Value,
-                                Convert.ToInt16(row.SelectNodes("td")[2].InnerText.Trim()),
-                                Convert.ToInt16(row.SelectNodes("td")[3].InnerText.Trim()),
-                                GetStatus(tableIndex)
-                            ));
+                        foreach (HtmlNode row in table.SelectNodes("tr"))
+                        {
+                            //Add scraped player to list
+                            lstPlayers.Add(
+                                new DynamoLeagueScrape.Players.clsPlayers(
+                                    row.SelectNodes("td")[0].InnerText.Trim(),
+                                    team.ID,
+                                    row.SelectNodes("td")[1].InnerText.Trim(),
+                                    row.SelectNodes("td")[0].SelectSingleNode("img").Attributes[0].Value,
+                                    Convert.ToInt16(row.SelectNodes("td")[2].InnerText.Trim()),
+                                    Convert.ToInt16(row.SelectNodes("td")[3].InnerText.Trim()),
+                                    GetStatus(tableIndex)
+                                ));
+                        }
                     }
+
                     tableIndex += 1;
                 }
+            }
 
-                //Save Players List to DB
-                var playersRepository = Players.clsPlayers.CreatePlayersRepository(FFUpdates_DynamoLeagueScrape.Properties.Resources.connString);
-                foreach (Players.clsPlayers player in lstPlayers)
-                {
-                    playersRepository.UpdateSingle(player);
-                }
-
-
+            //Save Players List to DB
+            var playersRepository = Players.clsPlayers.CreatePlayersRepository(FFUpdates_DynamoLeagueScrape.Properties.Resources.connString);
+            foreach (Players.clsPlayers player in lstPlayers)
+            {
+                playersRepository.UpdateSingle(player);
             }
 
         }

--- a/FFUpdates-DynamoLeagueScrape/Program.cs
+++ b/FFUpdates-DynamoLeagueScrape/Program.cs
@@ -17,11 +17,11 @@ namespace DynamoLeagueScrape
                 //Scrape teams
                 HtmlDocument doc = ScrapeTeam(team.DynamoID);
 
+                int tableIndex = 0;
                 foreach (HtmlNode table in doc.DocumentNode.SelectNodes("//tbody"))
                 {
                     foreach (HtmlNode row in table.SelectNodes("tr"))
                     {
-
                         //Add scraped player to list
                         lstPlayers.Add(
                             new DynamoLeagueScrape.Players.clsPlayers(
@@ -30,9 +30,11 @@ namespace DynamoLeagueScrape
                                 row.SelectNodes("td")[1].InnerText.Trim(),
                                 row.SelectNodes("td")[0].SelectSingleNode("img").Attributes[0].Value,
                                 Convert.ToInt16(row.SelectNodes("td")[2].InnerText.Trim()),
-                                Convert.ToInt16(row.SelectNodes("td")[3].InnerText.Trim())
+                                Convert.ToInt16(row.SelectNodes("td")[3].InnerText.Trim()),
+                                GetStatus(tableIndex)
                             ));
                     }
+                    tableIndex += 1;
                 }
 
                 //Save Players List to DB
@@ -45,6 +47,21 @@ namespace DynamoLeagueScrape
 
             }
 
+        }
+
+        private static int GetStatus(int tableIndex)
+        {
+            switch (tableIndex)
+            {
+                case 0:
+                    return 2; // Rostered
+                case 1:
+                    return 1; // Cut/FA
+                case 2:
+                    return 2; // Rostered (Unsigned)
+                default:
+                    return 4; // Unknown
+            }
         }
 
         public static HtmlDocument ScrapeTeam(int teamID)


### PR DESCRIPTION
Change FFUpdate-DynamoLeagueScrape to handle player status for cut and unsigned player tables, also corrected issue where SQL Update was firing multiple times for the same players